### PR TITLE
Fix query key for view one dataset, change zod schema for date variables, add default values to edit dataset info form

### DIFF
--- a/api/src/datasets/datasets.controller.ts
+++ b/api/src/datasets/datasets.controller.ts
@@ -1,6 +1,6 @@
 /* eslint-disable perfectionist/sort-classes */
 
-import { $CreateDataset, $DatasetViewPagination, $EditDatasetInfo } from '@databank/core';
+import { $CreateDataset, $DatasetInfo, $DatasetViewPagination, $EditDatasetInfo } from '@databank/core';
 import { CurrentUser } from '@douglasneuroinformatics/libnest';
 import { Body, Controller, Delete, Get, Param, Patch, Post, UploadedFile, UseInterceptors } from '@nestjs/common';
 import { FileInterceptor } from '@nestjs/platform-express';
@@ -81,7 +81,7 @@ export class DatasetsController {
   @ApiOperation({ summary: 'Get All Available Datasets' })
   @Get()
   @RouteAccess({ role: 'STANDARD' })
-  getAvailable(@CurrentUser('id') currentUserId: string) {
+  getAvailable(@CurrentUser('id') currentUserId: string): Promise<$DatasetInfo[]> {
     return this.datasetsService.getAvailable(currentUserId);
   }
 

--- a/api/src/datasets/datasets.service.ts
+++ b/api/src/datasets/datasets.service.ts
@@ -520,7 +520,7 @@ export class DatasetsService {
     });
   }
 
-  async getAvailable(currentUserId: string) {
+  async getAvailable(currentUserId: string): Promise<$DatasetInfo[]> {
     const currentUser = await this.usersService.findById(currentUserId);
 
     const availableDatasets = await this.datasetModel.findMany({

--- a/core/src/columns.ts
+++ b/core/src/columns.ts
@@ -54,8 +54,8 @@ const $FloatSummary = z.object({
 });
 
 const $DatetimeSummary = z.object({
-  max: z.coerce.date(),
-  min: z.coerce.date()
+  max: z.iso.date().transform((dateStr) => new Date(dateStr)),
+  min: z.iso.date().transform((dateStr) => new Date(dateStr))
 });
 
 const $StringColumn = z.object({
@@ -110,7 +110,10 @@ const $EnumColumnSummary = $EnumColumn.omit({ enumData: true });
 const $DatetimeColumn = z.object({
   datetimeData: z.array(
     z.object({
-      value: z.coerce.date().optional()
+      value: z.iso
+        .date()
+        .transform((dateStr) => new Date(dateStr))
+        .optional()
     })
   ),
   datetimeSummary: $DatetimeSummary,
@@ -145,7 +148,10 @@ const $RawQueryColumn = z.object({
   datetimeData: z
     .object({
       value: z.object({
-        $date: z.coerce.date().nullable()
+        $date: z.iso
+          .date()
+          .transform((dateStr) => new Date(dateStr))
+          .nullable()
       })
     })
     .array()
@@ -163,8 +169,8 @@ const $RawQueryColumn = z.object({
     count: z.int().gte(0),
     datetimeSummary: z
       .object({
-        max: z.object({ $date: z.coerce.date() }),
-        min: z.object({ $date: z.coerce.date() })
+        max: z.object({ $date: z.iso.date().transform((dateStr) => new Date(dateStr)) }),
+        min: z.object({ $date: z.iso.date().transform((dateStr) => new Date(dateStr)) })
       })
       .nullable(),
     enumSummary: $EnumSummaryFromDB.nullable(),

--- a/core/src/columns.ts
+++ b/core/src/columns.ts
@@ -54,8 +54,8 @@ const $FloatSummary = z.object({
 });
 
 const $DatetimeSummary = z.object({
-  max: z.iso.date().transform((dateStr) => new Date(dateStr)),
-  min: z.iso.date().transform((dateStr) => new Date(dateStr))
+  max: z.union([z.iso.datetime().transform((dateStr) => new Date(dateStr)), z.date()]),
+  min: z.union([z.iso.datetime().transform((dateStr) => new Date(dateStr)), z.date()])
 });
 
 const $StringColumn = z.object({
@@ -169,8 +169,8 @@ const $RawQueryColumn = z.object({
     count: z.int().gte(0),
     datetimeSummary: z
       .object({
-        max: z.object({ $date: z.iso.date().transform((dateStr) => new Date(dateStr)) }),
-        min: z.object({ $date: z.iso.date().transform((dateStr) => new Date(dateStr)) })
+        max: z.object({ $date: z.union([z.iso.datetime().transform((dateStr) => new Date(dateStr)), z.date()]) }),
+        min: z.object({ $date: z.union([z.iso.datetime().transform((dateStr) => new Date(dateStr)), z.date()]) })
       })
       .nullable(),
     enumSummary: $EnumSummaryFromDB.nullable(),

--- a/core/src/datasets.ts
+++ b/core/src/datasets.ts
@@ -36,7 +36,7 @@ const $EditDatasetInfo = z.object({
 type $EditDatasetInfo = z.infer<typeof $EditDatasetInfo>;
 
 const $DatasetInfo = z.object({
-  createdAt: z.iso.date().transform((dateStr) => new Date(dateStr)),
+  createdAt: z.union([z.iso.datetime().transform((dateStr) => new Date(dateStr)), z.date()]),
   datasetType: $DatasetType,
   description: z.string().nullable(),
   id: z.string(),
@@ -46,7 +46,7 @@ const $DatasetInfo = z.object({
   name: z.string(),
   permission: $PermissionLevel,
   status: $DatasetStatus,
-  updatedAt: z.iso.date().transform((dateStr) => new Date(dateStr))
+  updatedAt: z.union([z.iso.datetime().transform((dateStr) => new Date(dateStr)), z.date()])
 });
 type $DatasetInfo = z.infer<typeof $DatasetInfo>;
 

--- a/core/src/datasets.ts
+++ b/core/src/datasets.ts
@@ -36,7 +36,7 @@ const $EditDatasetInfo = z.object({
 type $EditDatasetInfo = z.infer<typeof $EditDatasetInfo>;
 
 const $DatasetInfo = z.object({
-  createdAt: z.coerce.date(),
+  createdAt: z.iso.date().transform((dateStr) => new Date(dateStr)),
   datasetType: $DatasetType,
   description: z.string().nullable(),
   id: z.string(),
@@ -46,7 +46,7 @@ const $DatasetInfo = z.object({
   name: z.string(),
   permission: $PermissionLevel,
   status: $DatasetStatus,
-  updatedAt: z.coerce.date()
+  updatedAt: z.iso.date().transform((dateStr) => new Date(dateStr))
 });
 type $DatasetInfo = z.infer<typeof $DatasetInfo>;
 

--- a/core/src/projects.ts
+++ b/core/src/projects.ts
@@ -4,13 +4,13 @@ import { $ColumnType, $TabularColumnInfo, $TabularColumnSummary } from './column
 
 //===================== Project Info ================================
 const $ProjectInfo = z.object({
-  createdAt: z.coerce.date(),
+  createdAt: z.iso.date().transform((dateStr) => new Date(dateStr)),
   description: z.string().nullish(),
-  expiry: z.coerce.date(),
+  expiry: z.iso.date().transform((dateStr) => new Date(dateStr)),
   externalId: z.string().nullish(),
   id: z.string(),
   name: z.string(),
-  updatedAt: z.coerce.date(),
+  updatedAt: z.iso.date().transform((dateStr) => new Date(dateStr)),
   userIds: z.string().array()
 });
 type $ProjectInfo = z.infer<typeof $ProjectInfo>;
@@ -73,7 +73,7 @@ const $ProjectDataset = z.object({
 const $CreateProject = z.object({
   datasets: $ProjectDataset.array(),
   description: z.string().optional(),
-  expiry: z.coerce.date(),
+  expiry: z.iso.date().transform((dateStr) => new Date(dateStr)),
   externalId: z.string().optional(),
   name: z.string().min(1),
   userIds: z.string().array().min(1)
@@ -100,7 +100,7 @@ const $UpdateProject = z
       })
       .array(),
     description: z.string().optional(),
-    expiry: z.coerce.date(),
+    expiry: z.iso.date().transform((dateStr) => new Date(dateStr)),
     externalId: z.string().optional(),
     name: z.string().min(1),
     userIds: z.string().array().min(1)

--- a/core/src/projects.ts
+++ b/core/src/projects.ts
@@ -4,13 +4,13 @@ import { $ColumnType, $TabularColumnInfo, $TabularColumnSummary } from './column
 
 //===================== Project Info ================================
 const $ProjectInfo = z.object({
-  createdAt: z.iso.date().transform((dateStr) => new Date(dateStr)),
+  createdAt: z.union([z.iso.datetime().transform((dateStr) => new Date(dateStr)), z.date()]),
   description: z.string().nullish(),
-  expiry: z.iso.date().transform((dateStr) => new Date(dateStr)),
+  expiry: z.union([z.iso.datetime().transform((dateStr) => new Date(dateStr)), z.date()]),
   externalId: z.string().nullish(),
   id: z.string(),
   name: z.string(),
-  updatedAt: z.iso.date().transform((dateStr) => new Date(dateStr)),
+  updatedAt: z.union([z.iso.datetime().transform((dateStr) => new Date(dateStr)), z.date()]),
   userIds: z.string().array()
 });
 type $ProjectInfo = z.infer<typeof $ProjectInfo>;
@@ -73,7 +73,7 @@ const $ProjectDataset = z.object({
 const $CreateProject = z.object({
   datasets: $ProjectDataset.array(),
   description: z.string().optional(),
-  expiry: z.iso.date().transform((dateStr) => new Date(dateStr)),
+  expiry: z.union([z.iso.datetime().transform((dateStr) => new Date(dateStr)), z.date()]),
   externalId: z.string().optional(),
   name: z.string().min(1),
   userIds: z.string().array().min(1)
@@ -100,7 +100,7 @@ const $UpdateProject = z
       })
       .array(),
     description: z.string().optional(),
-    expiry: z.iso.date().transform((dateStr) => new Date(dateStr)),
+    expiry: z.union([z.iso.datetime().transform((dateStr) => new Date(dateStr)), z.date()]),
     externalId: z.string().optional(),
     name: z.string().min(1),
     userIds: z.string().array().min(1)

--- a/core/src/users.ts
+++ b/core/src/users.ts
@@ -3,7 +3,10 @@ import { z } from 'zod/v4';
 const $UserRole = z.enum(['ADMIN', 'STANDARD']);
 
 const $CreateUser = z.object({
-  confirmedAt: z.coerce.date().optional(),
+  confirmedAt: z.iso
+    .date()
+    .transform((dateStr) => new Date(dateStr))
+    .nullish(),
 
   datasetIds: z.string().array(),
 
@@ -17,7 +20,10 @@ const $CreateUser = z.object({
 
   role: z.optional($UserRole),
 
-  verifiedAt: z.coerce.date().nullable().optional()
+  verifiedAt: z.iso
+    .date()
+    .transform((dateStr) => new Date(dateStr))
+    .nullish()
 });
 
 type User = {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "databank",
   "type": "module",
-  "version": "0.0.1-alpha.13",
+  "version": "0.0.1-alpha.14",
   "private": true,
   "packageManager": "pnpm@10.7.1",
   "engines": {

--- a/web/src/features/dataset/pages/ViewOneDatasetPage.tsx
+++ b/web/src/features/dataset/pages/ViewOneDatasetPage.tsx
@@ -12,7 +12,6 @@ import { ChevronDownIcon } from '@heroicons/react/24/outline';
 import { useNavigate, useParams } from '@tanstack/react-router';
 import axios from 'axios';
 
-import { LoadingFallback } from '@/components';
 import { PageHeading } from '@/components/PageHeading';
 import { useAuthStore } from '@/stores/auth-store';
 
@@ -92,9 +91,9 @@ const ViewOneDatasetPage = ({
       .catch(console.error);
   });
 
-  if (!dataset) {
-    return <LoadingFallback />;
-  }
+  // if (!dataset) {
+  //   return <LoadingFallback />;
+  // }
 
   const datasetName = capitalize(dataset.name);
 

--- a/web/src/features/dataset/pages/ViewOneDatasetPage.tsx
+++ b/web/src/features/dataset/pages/ViewOneDatasetPage.tsx
@@ -207,7 +207,17 @@ const ViewOneDatasetPage = ({
               <Button
                 className="m-2"
                 variant={'primary'}
-                onClick={() => void navigate({ to: `/portal/datasets/edit-info/${dataset.id}` })}
+                onClick={() =>
+                  void navigate({
+                    to: `/portal/datasets/edit-info/${dataset.id}`,
+                    search: {
+                      name: dataset.name,
+                      description: dataset.description ?? undefined,
+                      license: dataset.license,
+                      permission: dataset.permission
+                    }
+                  })
+                }
               >
                 {t('editDatasetInfo')}
               </Button>

--- a/web/src/features/projects/pages/ViewOneProjectPage.tsx
+++ b/web/src/features/projects/pages/ViewOneProjectPage.tsx
@@ -152,7 +152,17 @@ const ViewOneProjectPage = () => {
                 <Button
                   className="m-2"
                   variant={'primary'}
-                  onClick={() => void navigate({ to: `/portal/projects/edit-info/${project.id}` })}
+                  onClick={() =>
+                    void navigate({
+                      to: `/portal/projects/edit-info/${project.id}`,
+                      search: {
+                        name: project.name,
+                        description: project.description,
+                        externalId: project.externalId,
+                        expiryDate: project.expiry
+                      }
+                    })
+                  }
                 >
                   {t('editProjectInfo')}
                 </Button>

--- a/web/src/routes/portal/datasets/$datasetId.tsx
+++ b/web/src/routes/portal/datasets/$datasetId.tsx
@@ -29,12 +29,7 @@ const getViewDatasetQueryOptions = (
       return $TabularDataset.parse(response.data);
     },
     queryKey: [
-      'dataset-query',
-      datasetId,
-      columnPagination.currentPage,
-      columnPagination.itemsPerPage,
-      rowPagination.currentPage,
-      rowPagination.itemsPerPage
+      `dataset-query-${datasetId}-colPage-${columnPagination.currentPage}-colItems-${columnPagination.itemsPerPage}-rowPage-${rowPagination.currentPage}-rowItems-${rowPagination.itemsPerPage}`
     ]
   });
 };

--- a/web/src/routes/portal/datasets/edit-info.$datasetId.tsx
+++ b/web/src/routes/portal/datasets/edit-info.$datasetId.tsx
@@ -1,7 +1,22 @@
-import { createFileRoute } from '@tanstack/react-router';
+/* eslint-disable perfectionist/sort-objects */
+import { $PermissionLevel } from '@databank/core';
+import { createFileRoute, useSearch } from '@tanstack/react-router';
+import z from 'zod/v4';
 
 import { EditDatasetInfoPage } from '@/features/dataset/pages/EditDatasetInfoPage';
 
+const $EditDatasetInfoSearchParams = z.object({
+  description: z.string().optional(),
+  license: z.string(),
+  name: z.string(),
+  permission: $PermissionLevel
+});
+type $EditDatasetInfoSearchParams = z.infer<typeof $EditDatasetInfoSearchParams>;
+
 export const Route = createFileRoute('/portal/datasets/edit-info/$datasetId')({
-  component: EditDatasetInfoPage
+  validateSearch: $EditDatasetInfoSearchParams,
+  component: () => {
+    const editDatasetSearchParams = useSearch({ from: '/portal/datasets/edit-info/$datasetId' });
+    return <EditDatasetInfoPage {...editDatasetSearchParams} />;
+  }
 });

--- a/web/src/routes/portal/projects/edit-info.$projectId.tsx
+++ b/web/src/routes/portal/projects/edit-info.$projectId.tsx
@@ -1,7 +1,21 @@
-import { createFileRoute } from '@tanstack/react-router';
+/* eslint-disable perfectionist/sort-objects */
+import { createFileRoute, useSearch } from '@tanstack/react-router';
+import z from 'zod/v4';
 
 import { EditProjectInfoPage } from '@/features/projects/pages/EditProjectInfoPage';
 
+const $EditProjectInfoSearchParams = z.object({
+  name: z.string(),
+  description: z.string().optional(),
+  externalId: z.string().optional(),
+  expiryDate: z.union([z.iso.datetime().transform((dateStr) => new Date(dateStr)), z.date()])
+});
+type $EditProjectInfoSearchParams = z.infer<typeof $EditProjectInfoSearchParams>;
+
 export const Route = createFileRoute('/portal/projects/edit-info/$projectId')({
-  component: EditProjectInfoPage
+  validateSearch: $EditProjectInfoSearchParams,
+  component: () => {
+    const EditProjectInfoSearchParams = useSearch({ from: '/portal/projects/edit-info/$projectId' });
+    return <EditProjectInfoPage {...EditProjectInfoSearchParams} />;
+  }
 });

--- a/web/src/routes/public/dataset.$datasetId.tsx
+++ b/web/src/routes/public/dataset.$datasetId.tsx
@@ -29,12 +29,7 @@ const getPublicDatasetQueryOptions = (
       return $TabularDataset.parse(response.data);
     },
     queryKey: [
-      'dataset-query',
-      datasetId,
-      columnPagination.currentPage,
-      columnPagination.itemsPerPage,
-      rowPagination.currentPage,
-      rowPagination.itemsPerPage
+      `public-dataset-query-${datasetId}-colPage-${columnPagination.currentPage}-colItems-${columnPagination.itemsPerPage}-rowPage-${rowPagination.currentPage}-rowItems-${rowPagination.itemsPerPage}`
     ]
   });
 };

--- a/web/src/translations/common.json
+++ b/web/src/translations/common.json
@@ -521,7 +521,7 @@
   },
   "newProjectExpiryDate": {
     "en": "New Expiry Date",
-    "fr": "Nouvelle date d’expiration"
+    "fr": "Nouvelle date d'expiration"
   },
   "setDatasetSharable": {
     "en": "Set Dataset Sharable",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Edit Dataset/Project Info pages now show current values in placeholders and labels; navigating to edit pre-fills fields.
  - Route-level validation added for edit parameters to ensure valid inputs.

- Refactor
  - Broadened date/time handling across datasets, projects, and column summaries (accepts datetime strings or Date objects).
  - Adjusted dataset view caching keys for more consistent cache behavior.

- Chores
  - Bumped release to 0.0.1-alpha.14.

- Bug Fixes
  - Minor translation punctuation fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->