### PR TITLE
Standardize date/time handling on ISO8601

### DIFF
--- a/api/prisma/schema/_main.prisma
+++ b/api/prisma/schema/_main.prisma
@@ -30,7 +30,7 @@ model User {
 
   role UserRole @default(STANDARD)
 
-  createdAt DateTime @default(now()) @db.Date
+  createdAt DateTime @default(now())
 
   confirmEmailInfo ConfirmEmailInfo?
 
@@ -58,8 +58,8 @@ model Dataset {
   id             String          @id @default(auto()) @map("_id") @db.ObjectId
   name           String
   description    String?
-  createdAt      DateTime        @default(now()) @db.Date
-  updatedAt      DateTime        @default(now()) @updatedAt @db.Date
+  createdAt      DateTime        @default(now())
+  updatedAt      DateTime        @default(now()) @updatedAt
   license        String
   managers       User[]          @relation(fields: [managerIds], references: [id])
   managerIds     String[]        @db.ObjectId

--- a/api/prisma/schema/projects.prisma
+++ b/api/prisma/schema/projects.prisma
@@ -5,8 +5,8 @@ model Project {
     name        String
     description String?
     userIds     String[]
-    createdAt   DateTime         @default(now()) @db.Date
-    updatedAt   DateTime         @default(now()) @updatedAt @db.Date
+    createdAt   DateTime         @default(now())
+    updatedAt   DateTime         @default(now()) @updatedAt
     expiry      DateTime
     // Each project dataset should contain filters on columns 
     datasets    ProjectDataset[]

--- a/api/prisma/schema/setup.prisma
+++ b/api/prisma/schema/setup.prisma
@@ -11,8 +11,8 @@ type UserVerificationStrategy {
 
 model SetupConfig {
   id                   String                   @id @default(auto()) @map("_id") @db.ObjectId
-  createdAt            DateTime                 @default(now()) @db.Date
-  updatedAt            DateTime                 @default(now()) @updatedAt @db.Date
+  createdAt            DateTime                 @default(now())
+  updatedAt            DateTime                 @default(now()) @updatedAt
   isDemo               Boolean
   verificationStrategy UserVerificationStrategy
 }

--- a/api/src/auth/auth.service.ts
+++ b/api/src/auth/auth.service.ts
@@ -69,7 +69,7 @@ export class AuthService {
 
     // If there is an existing, non-expired code, use that since we record attempts for security
     let confirmEmailInfo: ConfirmEmailInfo;
-    if (user.confirmEmailInfo && user.confirmEmailInfo.expiryAt > new Date(Date.now())) {
+    if (user.confirmEmailInfo && user.confirmEmailInfo.expiryAt > new Date()) {
       confirmEmailInfo = user.confirmEmailInfo;
     } else {
       confirmEmailInfo = {
@@ -99,7 +99,7 @@ export class AuthService {
       throw new ForbiddenException('Validation code is undefined. Please request a validation code.');
     }
 
-    const isExpired = user.confirmEmailInfo.expiryAt < new Date(Date.now());
+    const isExpired = user.confirmEmailInfo.expiryAt < new Date();
     if (isExpired) {
       throw new ForbiddenException('Validation code is expired. Please request a new validation code.');
     }

--- a/api/src/columns/columns.service.ts
+++ b/api/src/columns/columns.service.ts
@@ -14,6 +14,14 @@ import type { Series } from 'nodejs-polars';
 
 import { getColumnDataArray } from './column-data.utils';
 
+/**
+ * Polars `pl.Date` series expose their values as integers counting days since
+ * the Unix epoch (1970-01-01). Multiplying by this constant converts a day
+ * count into the millisecond timestamp expected by `new Date(...)`. The
+ * resulting instant is interpreted in UTC.
+ */
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
 type ProjectColumnView = Pick<
   NonNullable<Awaited<ReturnType<Model<'TabularColumn'>['findUnique']>>>,
   | 'dataPermission'
@@ -589,8 +597,8 @@ export class ColumnsService {
         return {
           count: currSeries.len() - currSeries.nullCount(),
           datetimeSummary: {
-            max: new Date(currSeries.max() * 24 * 3600 * 1000),
-            min: new Date(currSeries.min() * 24 * 3600 * 1000)
+            max: new Date(currSeries.max() * MS_PER_DAY),
+            min: new Date(currSeries.min() * MS_PER_DAY)
           },
           nullCount: currSeries.nullCount()
         };

--- a/api/src/datasets/datasets.service.ts
+++ b/api/src/datasets/datasets.service.ts
@@ -12,7 +12,8 @@ import {
   $ProjectDataset,
   $TabularColumnSummary,
   $TabularDataDownloadFormat,
-  $TabularDatasetView
+  $TabularDatasetView,
+  formatISODateTime
 } from '@databank/core';
 import type { $DatasetCardProps, $DatasetInfo, $TabularDataset } from '@databank/core';
 import type { Model } from '@douglasneuroinformatics/libnest';
@@ -776,8 +777,8 @@ export class DatasetsService {
             datasetMetadata.nullable,
             datasetMetadata.count,
             datasetMetadata.nullCount,
-            datasetMetadata.datetimeSummary.max,
-            datasetMetadata.datetimeSummary.min,
+            formatISODateTime(datasetMetadata.datetimeSummary.max),
+            formatISODateTime(datasetMetadata.datetimeSummary.min),
             '',
             '',
             '',

--- a/api/src/tabular-data/tabular-data.service.ts
+++ b/api/src/tabular-data/tabular-data.service.ts
@@ -5,7 +5,8 @@ import {
   $ProjectTabularDatasetView,
   $TabularColumnSummary,
   $TabularDatasetView,
-  $UpdatePrimaryKeys
+  $UpdatePrimaryKeys,
+  formatISODateTime
 } from '@databank/core';
 import type { Model } from '@douglasneuroinformatics/libnest';
 import { InjectModel } from '@douglasneuroinformatics/libnest';
@@ -145,7 +146,7 @@ export class TabularDataService {
         case 'DATETIME':
           currColumnView.datetimeData.map((entry, i) => {
             rows[i] ??= {};
-            rows[i][currColumnView.name] = entry.value!.toDateString()!;
+            rows[i][currColumnView.name] = formatISODateTime(entry.value!);
           });
           metaData[currColumnView.name] = {
             count: currColumnView.summary.count,
@@ -298,7 +299,7 @@ export class TabularDataService {
             if (columnIdsModifyData.has(col._id.$oid)) {
               rows[i][col.name] = 'Hidden';
             } else {
-              rows[i][col.name] = entry.value.$date ? new Date(entry.value.$date).toDateString() : null;
+              rows[i][col.name] = entry.value.$date ? formatISODateTime(new Date(entry.value.$date)) : null;
             }
           });
 

--- a/core/package.json
+++ b/core/package.json
@@ -10,9 +10,13 @@
   "scripts": {
     "lint": "tsc && eslint --fix src"
   },
+  "devDependencies": {
+    "@types/luxon": "catalog:"
+  },
   "dependencies": {
     "@douglasneuroinformatics/libjs": "catalog:",
     "@douglasneuroinformatics/liblicense": "^1.0.0",
+    "luxon": "catalog:",
     "type-fest": "catalog:",
     "zod": "catalog:"
   }

--- a/core/src/dates.ts
+++ b/core/src/dates.ts
@@ -8,7 +8,11 @@ import { DateTime } from 'luxon';
  * the server's local zone.
  */
 export const formatISODate = (date: Date): string => {
-  return DateTime.fromJSDate(date, { zone: 'utc' }).toISODate()!;
+  const dt = DateTime.fromJSDate(date, { zone: 'utc' });
+  if (!dt.isValid) {
+    throw new TypeError(`Invalid Date: ${String(date)}`);
+  }
+  return dt.toISODate();
 };
 
 /**
@@ -18,7 +22,11 @@ export const formatISODate = (date: Date): string => {
  * the full precision of the instant is preserved across systems.
  */
 export const formatISODateTime = (date: Date): string => {
-  return DateTime.fromJSDate(date, { zone: 'utc' }).toISO()!;
+  const dt = DateTime.fromJSDate(date, { zone: 'utc' });
+  if (!dt.isValid) {
+    throw new TypeError(`Invalid Date: ${String(date)}`);
+  }
+  return dt.toISO();
 };
 
 /**

--- a/core/src/dates.ts
+++ b/core/src/dates.ts
@@ -1,0 +1,36 @@
+import { DateTime } from 'luxon';
+
+/**
+ * Format a Date as an ISO8601 calendar date (`YYYY-MM-DD`).
+ *
+ * Used for user-facing display where time-of-day is not relevant. Forces UTC
+ * to avoid off-by-one drift when the stored instant falls near midnight in
+ * the server's local zone.
+ */
+export const formatISODate = (date: Date): string => {
+  return DateTime.fromJSDate(date, { zone: 'utc' }).toISODate()!;
+};
+
+/**
+ * Format a Date as a full ISO8601 datetime with UTC offset (`YYYY-MM-DDTHH:mm:ss.sssZ`).
+ *
+ * Use this at storage/transport boundaries (API responses, CSV exports) so that
+ * the full precision of the instant is preserved across systems.
+ */
+export const formatISODateTime = (date: Date): string => {
+  return DateTime.fromJSDate(date, { zone: 'utc' }).toISO()!;
+};
+
+/**
+ * Parse an ISO8601 string (date or datetime) into a Date.
+ *
+ * Throws if the input is not a valid ISO8601 string. Forces UTC so the returned
+ * Date represents the same instant regardless of the host's local timezone.
+ */
+export const parseISODate = (input: string): Date => {
+  const dt = DateTime.fromISO(input, { zone: 'utc' });
+  if (!dt.isValid) {
+    throw new TypeError(`Invalid ISO8601 date string: ${input}`);
+  }
+  return dt.toJSDate();
+};

--- a/core/src/index.ts
+++ b/core/src/index.ts
@@ -2,6 +2,7 @@ export * from './auth';
 export * from './columns';
 export * from './dashboard';
 export * from './datasets';
+export * from './dates';
 export * from './demo';
 export * from './licenses';
 export * from './projects';

--- a/core/src/users.ts
+++ b/core/src/users.ts
@@ -27,13 +27,13 @@ const $CreateUser = z.object({
 });
 
 type User = {
-  confirmedAt: null | number | undefined;
-  creationTime?: number;
+  confirmedAt: Date | null | undefined;
+  creationTime?: Date;
   email: string;
   firstName: string;
   lastName: string;
   role: $UserRole;
-  verifiedAt: null | number | undefined;
+  verifiedAt: Date | null | undefined;
 };
 
 type $CreateUser = z.infer<typeof $CreateUser>;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,6 +9,12 @@ catalogs:
     '@douglasneuroinformatics/libjs':
       specifier: ^3.1.0
       version: 3.2.1
+    '@types/luxon':
+      specifier: ^3.7.0
+      version: 3.7.2
+    luxon:
+      specifier: ^3.7.2
+      version: 3.7.2
     type-fest:
       specifier: ^4.26.1
       version: 4.41.0
@@ -140,12 +146,19 @@ importers:
       '@douglasneuroinformatics/liblicense':
         specifier: ^1.0.0
         version: 1.0.0
+      luxon:
+        specifier: 'catalog:'
+        version: 3.7.2
       type-fest:
         specifier: 'catalog:'
         version: 4.41.0
       zod:
         specifier: 'catalog:'
         version: 3.25.76
+    devDependencies:
+      '@types/luxon':
+        specifier: 'catalog:'
+        version: 3.7.2
 
   web:
     dependencies:
@@ -2787,6 +2800,10 @@ packages:
   '@types/jsonwebtoken@9.0.10':
     resolution:
       { integrity: sha512-asx5hIG9Qmf/1oStypjanR7iKTv0gXQ1Ov/jfrX6kS/EO0OFni8orbmGCn0672NHR3kXHwpAwR+B368ZGN/2rA== }
+
+  '@types/luxon@3.7.2':
+    resolution:
+      { integrity: sha512-gW+Oib+vUtGJBtNC8V9Reww0oIpusw+4m81uncg9REGZAJfqOQHfo/nkabnc7w0QReXyPqjrbWMJk6NuAkiX3Q== }
 
   '@types/methods@1.1.4':
     resolution:
@@ -8955,6 +8972,8 @@ snapshots:
     dependencies:
       '@types/ms': 2.1.0
       '@types/node': 22.20.0
+
+  '@types/luxon@3.7.2': {}
 
   '@types/methods@1.1.4': {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -13,6 +13,8 @@ allowBuilds:
   msgpackr-extract: true
 catalog:
   '@douglasneuroinformatics/libjs': ^3.1.0
+  '@types/luxon': ^3.7.0
+  luxon: ^3.7.2
   type-fest: ^4.26.1
   zod: '3.25.x'
 minimumReleaseAge: 10080

--- a/web/src/hooks/queries/useProjectQuery.ts
+++ b/web/src/hooks/queries/useProjectQuery.ts
@@ -1,17 +1,18 @@
+import { parseISODate } from '@databank/core';
 import { queryOptions, useSuspenseQuery } from '@tanstack/react-query';
 import axios from 'axios';
 import { z } from 'zod/v4';
 
 // TODO - this needs to be synced correctly with the backend
 const $Project = z.object({
-  createdAt: z.coerce.date(),
+  createdAt: z.union([z.iso.datetime(), z.iso.date()]).transform(parseISODate),
   datasets: z.array(z.any()),
   description: z.string().nullish(),
-  expiry: z.coerce.date(),
+  expiry: z.union([z.iso.datetime(), z.iso.date()]).transform(parseISODate),
   externalId: z.string().nullish(),
   id: z.string(),
   name: z.string(),
-  updatedAt: z.coerce.date(),
+  updatedAt: z.union([z.iso.datetime(), z.iso.date()]).transform(parseISODate),
   userIds: z.array(z.string())
 });
 

--- a/web/src/routes/_public/datasets/$datasetId.tsx
+++ b/web/src/routes/_public/datasets/$datasetId.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable perfectionist/sort-objects */
 
-import { $DatasetViewPagination, licensesObjects } from '@databank/core';
+import { $DatasetViewPagination, formatISODate, licensesObjects } from '@databank/core';
 import { Badge, Card } from '@douglasneuroinformatics/libui/components';
 import { useTranslation } from '@douglasneuroinformatics/libui/hooks';
 import { createFileRoute } from '@tanstack/react-router';
@@ -164,14 +164,14 @@ const RouteComponent = () => {
                   <CalendarIcon className="size-3.5" />
                   {t({ en: 'Created', fr: 'Créé' })}
                 </dt>
-                <dd className="text-sm font-medium">{new Date(dataset.createdAt).toLocaleDateString()}</dd>
+                <dd className="text-sm font-medium">{formatISODate(new Date(dataset.createdAt))}</dd>
               </div>
               <div className="flex items-center justify-between">
                 <dt className="text-muted-foreground flex items-center gap-2 text-sm">
                   <ClockIcon className="size-3.5" />
                   {t({ en: 'Updated', fr: 'Mis à jour' })}
                 </dt>
-                <dd className="text-sm font-medium">{new Date(dataset.updatedAt).toLocaleDateString()}</dd>
+                <dd className="text-sm font-medium">{formatISODate(new Date(dataset.updatedAt))}</dd>
               </div>
             </dl>
           </Card.Content>

--- a/web/src/routes/_public/datasets/index.tsx
+++ b/web/src/routes/_public/datasets/index.tsx
@@ -1,4 +1,4 @@
-import { licensesObjects } from '@databank/core';
+import { formatISODate, licensesObjects } from '@databank/core';
 import type { $DatasetInfo } from '@databank/core';
 import { Button, Card } from '@douglasneuroinformatics/libui/components';
 import { useTranslation } from '@douglasneuroinformatics/libui/hooks';
@@ -36,7 +36,7 @@ const DatasetCard: React.FC<{ dataset: $DatasetInfo; index: number }> = ({ datas
               {dataset.license}
             </dd>
             <dt className="font-medium">{t({ en: 'Created', fr: 'Créé' })}</dt>
-            <dd>{new Date(dataset.createdAt).toLocaleDateString()}</dd>
+            <dd>{formatISODate(new Date(dataset.createdAt))}</dd>
           </dl>
         </Card.Content>
         <Card.Footer className="mt-auto pt-3">

--- a/web/src/routes/portal/datasets/$datasetId/index.tsx
+++ b/web/src/routes/portal/datasets/$datasetId/index.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable perfectionist/sort-objects */
 
-import { $DatasetViewPagination, licensesObjects } from '@databank/core';
+import { $DatasetViewPagination, formatISODate, licensesObjects } from '@databank/core';
 import type { $DatasetViewPagination as DatasetViewPaginationType } from '@databank/core';
 import { Button, Card, DropdownMenu } from '@douglasneuroinformatics/libui/components';
 import { useDestructiveAction, useDownload, useTranslation } from '@douglasneuroinformatics/libui/hooks';
@@ -161,11 +161,11 @@ const RouteComponent = () => {
           <dl className="grid gap-x-6 gap-y-4 sm:grid-cols-2 lg:grid-cols-4">
             <div>
               <dt className="text-muted-foreground text-xs font-medium uppercase tracking-wider">{t('createdAt')}</dt>
-              <dd className="mt-1.5 text-sm">{new Date(dataset.createdAt).toLocaleDateString()}</dd>
+              <dd className="mt-1.5 text-sm">{formatISODate(new Date(dataset.createdAt))}</dd>
             </div>
             <div>
               <dt className="text-muted-foreground text-xs font-medium uppercase tracking-wider">{t('updatedAt')}</dt>
-              <dd className="mt-1.5 text-sm">{new Date(dataset.updatedAt).toLocaleDateString()}</dd>
+              <dd className="mt-1.5 text-sm">{formatISODate(new Date(dataset.updatedAt))}</dd>
             </div>
             <div>
               <dt className="text-muted-foreground text-xs font-medium uppercase tracking-wider">

--- a/web/src/routes/portal/datasets/index.tsx
+++ b/web/src/routes/portal/datasets/index.tsx
@@ -1,4 +1,4 @@
-import { $DatasetInfo } from '@databank/core';
+import { $DatasetInfo, formatISODate } from '@databank/core';
 import { Badge, Button, Card, DropdownMenu } from '@douglasneuroinformatics/libui/components';
 import { useDestructiveAction, useTranslation } from '@douglasneuroinformatics/libui/hooks';
 import { createFileRoute, useNavigate } from '@tanstack/react-router';
@@ -44,7 +44,7 @@ const DatasetCard = ({ dataset, isManager }: { dataset: $DatasetInfo; isManager:
           <dt className="font-medium">{t({ en: 'License', fr: 'Licence' })}</dt>
           <dd className="truncate">{dataset.license}</dd>
           <dt className="font-medium">{t({ en: 'Created', fr: 'Créé le' })}</dt>
-          <dd>{new Date(dataset.createdAt).toLocaleDateString()}</dd>
+          <dd>{formatISODate(new Date(dataset.createdAt))}</dd>
         </dl>
       </Card.Content>
       <Card.Footer className="mt-auto flex items-center justify-between gap-2 pt-3">

--- a/web/src/routes/portal/projects/$projectId/add-dataset.tsx
+++ b/web/src/routes/portal/projects/$projectId/add-dataset.tsx
@@ -1,4 +1,4 @@
-import { licensesObjects } from '@databank/core';
+import { formatISODate, licensesObjects } from '@databank/core';
 import { Button, Card } from '@douglasneuroinformatics/libui/components';
 import { useTranslation } from '@douglasneuroinformatics/libui/hooks';
 import { createFileRoute, useNavigate } from '@tanstack/react-router';
@@ -73,7 +73,7 @@ const RouteComponent = () => {
                       </p>
                       <p>
                         <span className="font-semibold tracking-tight">{t({ en: 'Created: ', fr: 'Créé : ' })}</span>
-                        {new Date(dataset.createdAt).toLocaleDateString()}
+                        {formatISODate(new Date(dataset.createdAt))}
                       </p>
                     </div>
                   </div>

--- a/web/src/routes/portal/projects/$projectId/datasets.$datasetId/index.tsx
+++ b/web/src/routes/portal/projects/$projectId/datasets.$datasetId/index.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable perfectionist/sort-objects */
-import { $DatasetViewPagination, licensesObjects } from '@databank/core';
+import { $DatasetViewPagination, formatISODate, licensesObjects } from '@databank/core';
 import type { $DatasetViewPagination as DatasetViewPaginationType } from '@databank/core';
 import { Button, Card, DropdownMenu } from '@douglasneuroinformatics/libui/components';
 import { useDestructiveAction, useDownload, useTranslation } from '@douglasneuroinformatics/libui/hooks';
@@ -132,11 +132,11 @@ const RouteComponent = () => {
           <dl className="grid gap-x-6 gap-y-4 sm:grid-cols-2 lg:grid-cols-4">
             <div>
               <dt className="text-muted-foreground text-xs font-medium uppercase tracking-wider">{t('createdAt')}</dt>
-              <dd className="mt-1.5 text-sm">{new Date(dataset.createdAt).toLocaleDateString()}</dd>
+              <dd className="mt-1.5 text-sm">{formatISODate(new Date(dataset.createdAt))}</dd>
             </div>
             <div>
               <dt className="text-muted-foreground text-xs font-medium uppercase tracking-wider">{t('updatedAt')}</dt>
-              <dd className="mt-1.5 text-sm">{new Date(dataset.updatedAt).toLocaleDateString()}</dd>
+              <dd className="mt-1.5 text-sm">{formatISODate(new Date(dataset.updatedAt))}</dd>
             </div>
             <div>
               <dt className="text-muted-foreground text-xs font-medium uppercase tracking-wider">

--- a/web/src/routes/portal/projects/$projectId/index.tsx
+++ b/web/src/routes/portal/projects/$projectId/index.tsx
@@ -1,4 +1,4 @@
-import { licensesObjects } from '@databank/core';
+import { formatISODate, licensesObjects } from '@databank/core';
 import { Button, Card, DropdownMenu } from '@douglasneuroinformatics/libui/components';
 import { useDestructiveAction, useTranslation } from '@douglasneuroinformatics/libui/hooks';
 import { createFileRoute, useNavigate } from '@tanstack/react-router';
@@ -109,11 +109,11 @@ const RouteComponent = () => {
           <dl className="grid gap-x-6 gap-y-4 sm:grid-cols-2 lg:grid-cols-4">
             <div>
               <dt className="text-muted-foreground text-xs font-medium uppercase tracking-wider">{t('createdAt')}</dt>
-              <dd className="mt-1.5 text-sm">{new Date(project.createdAt).toLocaleDateString()}</dd>
+              <dd className="mt-1.5 text-sm">{formatISODate(new Date(project.createdAt))}</dd>
             </div>
             <div>
               <dt className="text-muted-foreground text-xs font-medium uppercase tracking-wider">{t('updatedAt')}</dt>
-              <dd className="mt-1.5 text-sm">{new Date(project.updatedAt).toLocaleDateString()}</dd>
+              <dd className="mt-1.5 text-sm">{formatISODate(new Date(project.updatedAt))}</dd>
             </div>
             <div>
               <dt className="text-muted-foreground text-xs font-medium uppercase tracking-wider">
@@ -127,7 +127,7 @@ const RouteComponent = () => {
               </dt>
               <dd className="mt-1.5 flex items-center gap-1 text-sm">
                 <CalendarIcon className="text-muted-foreground size-3.5" />
-                {new Date(project.expiry).toLocaleDateString()}
+                {formatISODate(new Date(project.expiry))}
               </dd>
             </div>
           </dl>
@@ -181,7 +181,7 @@ const RouteComponent = () => {
                         <span className="font-semibold tracking-tight">
                           {t({ en: 'Updated: ', fr: 'Mis à jour : ' })}
                         </span>
-                        {new Date(dataset.updatedAt).toLocaleDateString()}
+                        {formatISODate(new Date(dataset.updatedAt))}
                       </p>
                     </div>
                   </div>

--- a/web/src/routes/portal/projects/index.tsx
+++ b/web/src/routes/portal/projects/index.tsx
@@ -1,4 +1,4 @@
-import { $ProjectInfo } from '@databank/core';
+import { $ProjectInfo, formatISODate } from '@databank/core';
 import { Button, Card } from '@douglasneuroinformatics/libui/components';
 import { useNotificationsStore, useTranslation } from '@douglasneuroinformatics/libui/hooks';
 import { createFileRoute, useNavigate } from '@tanstack/react-router';
@@ -29,7 +29,7 @@ const ProjectCard = ({ project }: { project: $ProjectInfo }) => {
           <dt className="font-medium">{t('projectExpiry')}</dt>
           <dd className="flex items-center gap-1">
             <CalendarIcon className="size-3" />
-            {new Date(project.expiry).toLocaleDateString()}
+            {formatISODate(new Date(project.expiry))}
           </dd>
         </dl>
       </Card.Content>


### PR DESCRIPTION
## Summary

Standardize all date/time handling on ISO8601 across the codebase. Adds Luxon as the date library, introduces shared helpers in `@databank/core`, and fixes every non-compliant emission/display site found in a full audit.

## Audit findings (now fixed)

- **API emitted non-ISO strings** — `toDateString()` (`"Wed Jul 14 2026"`) in dataset row payloads and CSV metadata exports.
- **14× `toLocaleDateString()`** with no locale arg in `web/` — locale-indeterminate display.
- **Prisma `@db.Date`** on `createdAt`/`updatedAt` truncated the time portion.
- **Loose client parsing** — `z.coerce.date()` accepted non-ISO strings.
- **Divergent `User` type** declared dates as `number` (unix ms).
- **Magic constants** (`24 * 3600 * 1000`) in polars day-since-epoch conversion.

## Changes by commit

1. `add luxon and ISO8601 date helpers in core` — new `core/src/dates.ts` exporting `formatISODate`, `formatISODateTime`, `parseISODate` (all UTC-forced).
2. `emit ISO8601 datetimes in dataset rows and CSV metadata` — `toDateString()` → `formatISODateTime()` in `tabular-data.service.ts` and `datasets.service.ts`.
3. `render ISO8601 dates in web UI via core helper` — 14 `toLocaleDateString()` sites → `formatISODate()` (ISO date-only display).
4. `migrate Prisma createdAt/updatedAt to full DateTime` — drop `@db.Date` from `User`, `Dataset`, `Project`, `SetupConfig`.
5. `align User type and project query parsing with ISO8601` — `User` date fields `number` → `Date | null | undefined`; `z.coerce.date()` → `z.union([z.iso.datetime(), z.iso.date()]).transform(parseISODate)`.
6. `replace date magic constants and simplify new Date calls` — `MS_PER_DAY` named constant with explanatory comment; `new Date(Date.now())` → `new Date()`.

## Notes

- **i18n**: UI now renders ISO date-only (`2026-07-14`) uniformly across `en`/`fr` locales. This is an intentional decision from the audit — flag if localized display is preferred instead.
- **Deploy**: requires `prisma db push` (or app sync) so MongoDB reflects the dropped `@db.Date`. Existing docs keep their midnight-UTC instants, so reads stay consistent.
- **Out of scope**: polars `tryParseDates: true` upload-date format validation (`file-upload.processor.ts`) — deferred to a separate task.

## Verification

- `pnpm lint` — clean across `core`, `api`, `web`
- `pnpm test` — 17/17 passing
